### PR TITLE
Small fixes for Centos 7

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Secure tunnels to localhost
   company: Phalcon Team
   license: MIT
-  min_ansible_version: 2.0
+  min_ansible_version: 2.2
   platforms:
     - name: EL
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   stat: "path={{ ngrok_install_path }}"
   register: ngrok_bin
 
-- name: Downmload ngrok
+- name: Download ngrok
   get_url:
     url: "{{ ngrok_download_url }}"
     dest: /tmp/ngrok.zip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
     src: /tmp/ngrok.zip
     dest: /tmp
     creates: path=/tmp/ngrok
+    remote_src: yes
   when: not ngrok_bin.stat.exists
 
 - name: Install ngrok

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
     dest: /tmp/ngrok.zip
   when: not ngrok_bin.stat.exists
 
-- name: Getting ngrok
+- name: Unarchive ngrok
   unarchive:
     src: /tmp/ngrok.zip
     dest: /tmp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,5 +33,8 @@
   when: not ngrok_bin.stat.exists
 
 - name: Remove no longer needed ngrok files
-  file: path=/tmp/ngrok.zip state=absent
+  file: path="{{ item }}" state=absent
+  with_items:
+    - /tmp/ngrok.zip
+    - /tmp/ngrok
   when: not ngrok_bin.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     mode: "u=rwx,g=rx,o=rx"
     owner: "{{ ngrok_bin_owner }}"
     group: "{{ ngrok_bin_group }}"
+    remote_src: yes
   when: not ngrok_bin.stat.exists
 
 - name: Remove no longer needed ngrok files


### PR DESCRIPTION
This was failing for me on the "Getting ngrok" step. Specifically:

```
TASK [phalcon.ngrok : Getting ngrok] *******************************************************************
fatal: [ep.jhu.devel]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to find '/tmp/ngrok.zip' in expected paths."}
	to retry, use: --limit @./webserver-setup.retry
```

These changes resolve that issue and a similar issue with the "Install ngrok" step.

These changes were tested and work on CentOS 7 with Ansible 2.3. 